### PR TITLE
Changed docker registry for local-ydb docker image in quick-start article

### DIFF
--- a/ydb/docs/presets.yaml
+++ b/ydb/docs/presets.yaml
@@ -36,7 +36,7 @@ default:
   ydbd-install-url: https://install.ydb.tech
   ydb-cli-install-url: https://install.ydb.tech/cli
   ydb-stable-binary-archive: ydbd-stable-linux-amd64.tar.gz
-  ydb_local_docker_image: cr.yandex/yc/yandex-docker-local-ydb
+  ydb_local_docker_image: ydbplatform/ydb-local
   ydb_local_docker_image_tag: latest
   managed-k8s-full-name: Yandex Managed Service for Kubernetes
   managed-k8s-name: Managed Service for Kubernetes


### PR DESCRIPTION
Fixed docker registry for article https://ydb.tech/docs/en/quickstart

### Changelog category <!-- remove all except one -->

* Documentation (changelog entry is not required)